### PR TITLE
Improve responsive scaling across viewports

### DIFF
--- a/style.css
+++ b/style.css
@@ -35,7 +35,8 @@ body {
     background: radial-gradient(circle at top, rgba(56, 189, 248, 0.15), transparent 55%), linear-gradient(160deg, var(--bg-start), var(--bg-end));
     display: flex;
     justify-content: center;
-    padding: clamp(1rem, 2vw + 1rem, 3rem);
+    align-items: stretch;
+    padding: clamp(0.75rem, 1.5vw + 0.5rem, 2.5rem);
 }
 
 img {
@@ -43,10 +44,11 @@ img {
 }
 
 .app-shell {
-    width: min(1200px, 100%);
+    width: min(1100px, 100%);
+    margin: 0 auto;
     display: flex;
     flex-direction: column;
-    gap: clamp(1.25rem, 3vw, 2.5rem);
+    gap: clamp(1.1rem, 3vw, 2.25rem);
 }
 
 .header {
@@ -68,11 +70,11 @@ img {
 .table {
     display: none;
     flex-direction: column;
-    gap: clamp(1.5rem, 3vw, 2.5rem);
+    gap: clamp(1.1rem, 3vw, 2.25rem);
     background: var(--surface-strong);
     border-radius: var(--radius-lg);
     border: 1px solid var(--card-border);
-    padding: clamp(1.5rem, 3vw, 3rem);
+    padding: clamp(1.25rem, 2.5vw + 0.5rem, 2.75rem);
     box-shadow: var(--shadow-lg);
     backdrop-filter: blur(20px);
     overflow: hidden;
@@ -82,7 +84,7 @@ img {
     width: 100%;
     display: flex;
     flex-wrap: wrap;
-    gap: clamp(1rem, 3vw, 1.75rem);
+    gap: clamp(0.75rem, 2.5vw, 1.75rem);
     justify-content: space-between;
     align-items: stretch;
 }
@@ -96,12 +98,12 @@ img {
 }
 
 .col {
-    flex: 1 1 220px;
+    flex: 1 1 clamp(150px, 26vw, 220px);
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 0.75rem;
+    gap: clamp(0.55rem, 1.8vw, 0.85rem);
     text-align: center;
     color: var(--text-secondary);
 }
@@ -137,13 +139,13 @@ img {
     gap: 0.35rem;
     align-items: center;
     justify-content: center;
-    min-width: 170px;
-    padding: 0.85rem 1.5rem;
+    min-width: min(170px, 100%);
+    padding: clamp(0.65rem, 2vw, 0.85rem) clamp(1rem, 3vw, 1.5rem);
     border-radius: var(--radius-md);
     border: 1px solid rgba(148, 163, 184, 0.18);
     background: rgba(148, 163, 184, 0.08);
     font-weight: 600;
-    font-size: clamp(1.1rem, 2vw, 1.35rem);
+    font-size: clamp(1rem, 2vw, 1.25rem);
 }
 
 .stat-chip::before {
@@ -157,7 +159,7 @@ img {
 
 #your-type-name,
 #opponent-type-name {
-    min-height: 3.25rem;
+    min-height: 3rem;
     width: 100%;
     border-radius: var(--radius-md);
     border: 1px solid rgba(148, 163, 184, 0.16);
@@ -168,7 +170,7 @@ img {
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0.75rem 1rem;
+    padding: clamp(0.55rem, 1.5vw, 0.85rem) clamp(0.9rem, 2.5vw, 1.25rem);
     box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.35);
 }
 
@@ -178,14 +180,14 @@ img {
 
 .card {
     position: relative;
-    flex: 1 1 190px;
-    max-width: 240px;
-    min-height: 340px;
+    flex: 1 1 clamp(180px, 32vw, 240px);
+    max-width: clamp(210px, 40vw, 260px);
+    min-height: clamp(250px, 52vw, 340px);
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 0.85rem;
-    padding: 1.15rem 0.95rem 1.5rem;
+    gap: clamp(0.65rem, 2vw, 0.95rem);
+    padding: clamp(0.85rem, 2vw, 1.2rem) clamp(0.75rem, 1.8vw, 1.1rem) clamp(1rem, 2.5vw, 1.6rem);
     border-radius: 24px;
     background: linear-gradient(185deg, var(--trump-navy) 0%, rgba(6, 54, 90, 0.9) 60%, rgba(14, 23, 42, 0.96) 100%);
     border: 3px solid var(--trump-gold);
@@ -226,15 +228,14 @@ img {
 }
 
 .card img {
-    width: 90%;
-    max-width: 180px;
+    width: min(100%, clamp(140px, 55vw, 190px));
     aspect-ratio: 3 / 4;
     object-fit: contain;
     border-radius: 18px;
     background: radial-gradient(circle at center, rgba(56, 189, 248, 0.22), rgba(15, 23, 42, 0.75) 80%);
     border: 2px solid rgba(248, 250, 252, 0.25);
     box-shadow: 0 16px 28px rgba(15, 23, 42, 0.6);
-    padding: 0.65rem;
+    padding: clamp(0.5rem, 1.5vw, 0.75rem);
 }
 
 .pokemon-label {
@@ -242,14 +243,14 @@ img {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 0.75rem;
-    padding: 0.55rem 0.9rem;
+    gap: clamp(0.5rem, 2vw, 0.85rem);
+    padding: clamp(0.45rem, 1.5vw, 0.65rem) clamp(0.6rem, 2vw, 0.95rem);
     border-radius: 18px;
     border: 2px solid rgba(255, 255, 255, 0.35);
     background: linear-gradient(135deg, var(--trump-gold), var(--trump-orange));
     color: #1f2937;
     font-weight: 800;
-    font-size: 0.85rem;
+    font-size: clamp(0.78rem, 1.6vw, 0.9rem);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     text-shadow: 0 1px 0 rgba(255, 255, 255, 0.55);
@@ -261,8 +262,8 @@ img {
 }
 
 .pokemon-label img {
-    width: 34px !important;
-    height: 26px !important;
+    width: clamp(26px, 8vw, 34px) !important;
+    height: clamp(20px, 6vw, 26px) !important;
     object-fit: contain;
     filter: drop-shadow(0 8px 12px rgba(8, 15, 35, 0.45));
 }
@@ -271,7 +272,7 @@ img {
     width: 100%;
     display: flex;
     flex-direction: column;
-    gap: 0.6rem;
+    gap: clamp(0.5rem, 1.5vw, 0.7rem);
 }
 
 .stat-options button {
@@ -279,14 +280,14 @@ img {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 0.75rem;
-    padding: 0.75rem 1rem;
+    gap: clamp(0.6rem, 2vw, 0.85rem);
+    padding: clamp(0.6rem, 1.8vw, 0.85rem) clamp(0.75rem, 2vw, 1rem);
     border-radius: 16px;
     border: 2px solid rgba(250, 204, 21, 0.25);
     background: rgba(15, 23, 42, 0.78);
     color: var(--text-primary);
     font-weight: 700;
-    font-size: 0.9rem;
+    font-size: clamp(0.8rem, 1.4vw, 0.95rem);
     letter-spacing: 0.04em;
     cursor: pointer;
     transition: var(--transition);
@@ -305,13 +306,13 @@ img {
 
 .stat-options button span:first-child {
     text-transform: uppercase;
-    font-size: 0.72rem;
+    font-size: clamp(0.64rem, 1.4vw, 0.75rem);
     letter-spacing: 0.14em;
     color: rgba(248, 250, 252, 0.75);
 }
 
 .stat-options button .stat-value {
-    font-size: 1.05rem;
+    font-size: clamp(0.9rem, 2vw, 1.05rem);
     font-weight: 800;
     color: var(--text-primary);
 }
@@ -356,16 +357,16 @@ img {
 
 .log {
     width: 100%;
-    min-height: 140px;
-    max-height: 240px;
-    padding: 1rem;
+    min-height: clamp(110px, 30vh, 160px);
+    max-height: clamp(160px, 45vh, 240px);
+    padding: clamp(0.75rem, 1.5vw, 1rem);
     border-radius: var(--radius-md);
     border: 1px solid rgba(148, 163, 184, 0.18);
     background: rgba(10, 18, 32, 0.65);
     color: var(--text-secondary);
     display: flex;
     flex-direction: column;
-    gap: 0.65rem;
+    gap: clamp(0.5rem, 1.5vw, 0.75rem);
     overflow-y: auto;
 }
 
@@ -374,13 +375,13 @@ img {
 }
 
 .primary-action {
-    margin-top: 1.5rem;
-    padding: 0.95rem 2.75rem;
+    margin-top: clamp(1rem, 2.5vw, 1.5rem);
+    padding: clamp(0.75rem, 2vw, 0.95rem) clamp(1.5rem, 6vw, 2.75rem);
     border-radius: 999px;
     border: none;
     outline: none;
     font-weight: 700;
-    font-size: 1rem;
+    font-size: clamp(0.9rem, 1.6vw, 1rem);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--text-primary);
@@ -400,11 +401,11 @@ img {
     width: 100%;
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
+    gap: clamp(1rem, 2.5vw, 1.5rem);
     background: var(--surface-strong);
     border-radius: var(--radius-lg);
     border: 1px solid var(--card-border);
-    padding: clamp(1.5rem, 3vw, 3rem);
+    padding: clamp(1.1rem, 3vw, 2.5rem);
     box-shadow: var(--shadow-lg);
     backdrop-filter: blur(18px);
     overflow: hidden;
@@ -424,19 +425,19 @@ img {
 }
 
 .menu-heading h2 {
-    font-size: clamp(1.75rem, 3vw, 2.25rem);
+    font-size: clamp(1.6rem, 3vw, 2.25rem);
     letter-spacing: 0.05em;
 }
 
 .menu-heading p {
     color: var(--text-secondary);
-    font-size: 1rem;
+    font-size: clamp(0.92rem, 1.5vw, 1rem);
 }
 
 .packs {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
-    gap: clamp(1rem, 2vw, 1.75rem);
+    grid-template-columns: repeat(auto-fit, minmax(clamp(140px, 30vw, 190px), 1fr));
+    gap: clamp(0.85rem, 2vw, 1.5rem);
 }
 
 .pokemon-pack {
@@ -444,8 +445,8 @@ img {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 0.85rem;
-    padding: 1.25rem;
+    gap: clamp(0.7rem, 2vw, 0.9rem);
+    padding: clamp(0.9rem, 2.5vw, 1.25rem);
     border-radius: var(--radius-md);
     border: 1px solid var(--card-border);
     background: rgba(12, 20, 35, 0.7);
@@ -463,8 +464,8 @@ img {
 }
 
 .pokemon-pack img {
-    width: 110px;
-    height: 110px;
+    width: clamp(80px, 25vw, 110px);
+    height: clamp(80px, 25vw, 110px);
     object-fit: contain;
     filter: drop-shadow(0 16px 24px rgba(8, 15, 35, 0.55));
 }
@@ -472,11 +473,11 @@ img {
 .rules {
     display: flex;
     flex-direction: column;
-    gap: 0.85rem;
+    gap: clamp(0.65rem, 2vw, 0.85rem);
     background: rgba(12, 20, 35, 0.65);
     border-radius: var(--radius-md);
     border: 1px solid rgba(148, 163, 184, 0.2);
-    padding: 1.5rem;
+    padding: clamp(1rem, 2.5vw, 1.5rem);
     color: var(--text-secondary);
     line-height: 1.6;
 }
@@ -489,8 +490,8 @@ img {
 .rules ol {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
-    padding-left: 1.25rem;
+    gap: clamp(0.4rem, 1.5vw, 0.6rem);
+    padding-left: clamp(1rem, 2.5vw, 1.25rem);
 }
 
 .rules li {
@@ -500,11 +501,11 @@ img {
 .type-chart {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: clamp(0.75rem, 2.5vw, 1rem);
     background: rgba(12, 20, 35, 0.65);
     border-radius: var(--radius-md);
     border: 1px solid rgba(148, 163, 184, 0.2);
-    padding: 1.5rem;
+    padding: clamp(1rem, 2.5vw, 1.5rem);
 }
 
 .type-chart-title {
@@ -575,13 +576,13 @@ img {
 
 @media (max-width: 1024px) {
     .card {
-        min-height: 320px;
+        min-height: clamp(240px, 48vw, 320px);
     }
 }
 
 @media (max-width: 860px) {
     body {
-        padding: 1.5rem;
+        padding: clamp(0.75rem, 1.5vw + 0.5rem, 2rem);
     }
 
     .table,
@@ -592,11 +593,12 @@ img {
 
     .card-row {
         flex-direction: column;
-        align-items: stretch;
+        align-items: center;
+        gap: clamp(0.85rem, 2vw, 1.25rem);
     }
 
     .card {
-        max-width: none;
+        max-width: min(360px, 100%);
         width: 100%;
     }
 
@@ -604,47 +606,42 @@ img {
     .type-row,
     .name-row {
         flex-direction: column;
-        gap: 1rem;
+        gap: clamp(0.75rem, 2vw, 1rem);
     }
 
     .stat-chip,
     #your-type-name,
     #opponent-type-name {
-        width: min(100%, 320px);
+        width: min(100%, 360px);
     }
 }
 
 @media (max-width: 600px) {
     body {
-        padding: 1rem;
+        padding: clamp(0.65rem, 1.5vw + 0.4rem, 1.25rem);
     }
 
     .app-shell {
-        gap: 1rem;
+        gap: clamp(0.85rem, 3vw, 1.1rem);
     }
 
     .table,
     .menu {
-        padding: 1.25rem 1.5rem;
+        padding: clamp(0.9rem, 3vw, 1.35rem);
     }
 
     .table .row {
-        gap: 1rem;
+        gap: clamp(0.7rem, 2vw, 1rem);
     }
 
     .badge {
-        font-size: 0.8rem;
-        padding: 0.5rem 1.2rem;
+        font-size: 0.78rem;
+        padding: 0.45rem 1.1rem;
     }
 
     .pokemon-label {
         flex-direction: column;
         align-items: flex-start;
-    }
-
-    .stat-options button {
-        font-size: 0.9rem;
-        padding: 0.75rem 1rem;
     }
 
     .primary-action {
@@ -657,23 +654,14 @@ img {
 }
 
 @media (max-width: 480px) {
-    body {
-        padding: 0.75rem;
-    }
-
-    .table,
-    .menu {
-        padding: 1.1rem 1.35rem;
-    }
-
     .header h1 {
-        font-size: 1.75rem;
+        font-size: clamp(1.5rem, 8vw, 1.8rem);
     }
 
     .table .row {
         flex-direction: column;
         align-items: stretch;
-        gap: 0.85rem;
+        gap: clamp(0.7rem, 2.4vw, 0.9rem);
     }
 
     .row-auto {
@@ -685,10 +673,6 @@ img {
         text-align: center;
     }
 
-    .badge {
-        align-self: center;
-    }
-
     .stat-chip,
     #your-type-name,
     #opponent-type-name {
@@ -696,133 +680,61 @@ img {
     }
 
     .card {
-        min-height: 310px;
-        padding: 1rem 0.8rem 1.25rem;
-    }
-
-    .card img {
-        max-width: 160px;
-        min-height: 360px;
-        padding: 1.25rem;
-    }
-
-    .card img {
-        padding: 0.5rem;
+        max-width: min(100%, 320px);
+        min-height: clamp(220px, 80vw, 300px);
+        padding: clamp(0.75rem, 3vw, 1rem) clamp(0.7rem, 3vw, 1rem) clamp(0.9rem, 4vw, 1.4rem);
     }
 
     .pokemon-label {
         width: 100%;
         align-items: flex-start;
-        gap: 0.5rem;
-        font-size: 0.8rem;
-        padding: 0.5rem 0.75rem;
-    }
-
-    .pokemon-label img {
-        width: 30px !important;
-        height: 22px !important;
+        gap: clamp(0.4rem, 3vw, 0.6rem);
+        font-size: clamp(0.72rem, 3vw, 0.82rem);
     }
 
     .stat-options {
-        gap: 0.65rem;
+        gap: clamp(0.45rem, 3vw, 0.6rem);
     }
 
     .stat-options button {
-        font-size: 0.85rem;
-        padding: 0.65rem 0.9rem;
+        padding: clamp(0.55rem, 3vw, 0.75rem) clamp(0.65rem, 3vw, 0.9rem);
+        font-size: clamp(0.75rem, 3vw, 0.88rem);
     }
 
     .stat-options button span:first-child {
-        font-size: 0.68rem;
+        font-size: clamp(0.6rem, 2.5vw, 0.7rem);
     }
 
     .stat-options button .stat-value {
-        font-size: 0.98rem;
-    }
-
-    .primary-action {
-        margin-top: 1.25rem;
-        padding: 0.85rem 2rem;
-        font-size: 0.95rem;
+        font-size: clamp(0.85rem, 3vw, 0.95rem);
     }
 
     .log {
-        min-height: 110px;
-        max-height: 180px;
-        padding: 0.85rem;
+        min-height: clamp(90px, 32vh, 140px);
+        padding: clamp(0.65rem, 2.5vw, 0.85rem);
     }
 
     .menu-heading h2 {
-        font-size: 1.5rem;
+        font-size: clamp(1.35rem, 7vw, 1.6rem);
     }
 
     .menu-heading p {
-        font-size: 0.95rem;
-    }
-
-    .pokemon-pack {
-        padding: 1rem;
-    }
-
-    .pokemon-pack img {
-        width: 90px;
-        height: 90px;
-    }
-
-    .rules,
-    .type-chart {
-        padding: 1.25rem;
+        font-size: clamp(0.85rem, 4vw, 0.95rem);
     }
 }
 
 @media (max-width: 360px) {
     body {
-        padding: 0.5rem;
-    }
-
-    .header h1 {
-        font-size: 1.55rem;
+        padding: clamp(0.5rem, 3vw, 0.65rem);
     }
 
     .card {
-        min-height: 290px;
-        padding: 0.95rem 0.75rem 1.1rem;
-    }
-
-    .pokemon-label {
-        font-size: 0.78rem;
-        padding: 0.5rem 0.75rem;
-    }
-
-    .stat-options button {
-        font-size: 0.78rem;
-        padding: 0.65rem 0.85rem;
-    }
-
-    .stat-options button span:first-child {
-        font-size: 0.64rem;
-    }
-
-    .stat-options button .stat-value {
-        font-size: 0.92rem;
-        min-height: 330px;
-        padding: 1.1rem;
-    }
-
-    .pokemon-label {
-        font-size: 0.85rem;
-    }
-
-    .stat-options button {
-        font-size: 0.8rem;
+        border-width: 2px;
     }
 
     .primary-action {
-        font-size: 0.9rem;
-    }
-
-    .menu-heading p {
-        font-size: 0.9rem;
+        font-size: 0.85rem;
+        padding: clamp(0.65rem, 4vw, 0.85rem);
     }
 }
 
@@ -832,6 +744,20 @@ img {
     }
 
     .app-shell {
-        gap: 1rem;
+        gap: clamp(0.75rem, 3vh, 1.25rem);
+    }
+}
+
+@media (max-height: 640px) {
+    body {
+        padding: clamp(0.5rem, 2vh, 0.85rem);
+    }
+
+    .card {
+        min-height: clamp(220px, 60vh, 300px);
+    }
+
+    .log {
+        max-height: clamp(140px, 40vh, 200px);
     }
 }


### PR DESCRIPTION
## Summary
- make the overall layout padding and gaps fluid so the app shell fits smaller screens
- scale card, stat, and menu components with clamp-based sizing for better readability on narrow devices
- refresh media queries to stack content and reduce heights on very small or short viewports

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d46d95a518832fac11401d1379f31f