### PR TITLE
Adjust layout spacing for compact viewport

### DIFF
--- a/style.css
+++ b/style.css
@@ -28,6 +28,12 @@
     box-sizing: border-box;
 }
 
+html,
+body {
+    width: 100%;
+    height: 100%;
+}
+
 body {
     min-height: 100vh;
     font-family: "Poppins", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
@@ -35,8 +41,8 @@ body {
     background: radial-gradient(circle at top, rgba(56, 189, 248, 0.15), transparent 55%), linear-gradient(160deg, var(--bg-start), var(--bg-end));
     display: flex;
     justify-content: center;
-    align-items: stretch;
-    padding: clamp(0.75rem, 1.5vw + 0.5rem, 2.5rem);
+    align-items: center;
+    padding: clamp(0.5rem, 1.5vw, 1.5rem);
 }
 
 img {
@@ -44,18 +50,21 @@ img {
 }
 
 .app-shell {
-    width: min(1100px, 100%);
-    margin: 0 auto;
+    width: min(100vw, 960px);
+    height: 100%;
+    margin: 0;
     display: flex;
     flex-direction: column;
-    gap: clamp(1.1rem, 3vw, 2.25rem);
+    align-items: center;
+    justify-content: center;
+    gap: clamp(0.75rem, 2vw, 1.5rem);
 }
 
 .header {
     background: var(--surface);
     border: 1px solid var(--card-border);
     border-radius: var(--radius-lg);
-    padding: clamp(1rem, 2vw, 2rem);
+    padding: clamp(0.75rem, 1.5vw, 1.5rem);
     text-align: center;
     box-shadow: var(--shadow-sm);
     backdrop-filter: blur(18px);
@@ -70,22 +79,24 @@ img {
 .table {
     display: none;
     flex-direction: column;
-    gap: clamp(1.1rem, 3vw, 2.25rem);
+    align-items: center;
+    gap: clamp(0.75rem, 2vw, 1.5rem);
     background: var(--surface-strong);
     border-radius: var(--radius-lg);
     border: 1px solid var(--card-border);
-    padding: clamp(1.25rem, 2.5vw + 0.5rem, 2.75rem);
+    padding: clamp(0.9rem, 2vw, 1.75rem);
     box-shadow: var(--shadow-lg);
     backdrop-filter: blur(20px);
-    overflow: hidden;
+    max-height: calc(100vh - clamp(4rem, 12vh, 6rem));
+    overflow-y: auto;
 }
 
 .table .row {
     width: 100%;
     display: flex;
     flex-wrap: wrap;
-    gap: clamp(0.75rem, 2.5vw, 1.75rem);
-    justify-content: space-between;
+    gap: clamp(0.5rem, 1.75vw, 1.25rem);
+    justify-content: center;
     align-items: stretch;
 }
 
@@ -98,12 +109,12 @@ img {
 }
 
 .col {
-    flex: 1 1 clamp(150px, 26vw, 220px);
+    flex: 1 1 clamp(140px, 24vw, 200px);
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: clamp(0.55rem, 1.8vw, 0.85rem);
+    gap: clamp(0.45rem, 1.4vw, 0.75rem);
     text-align: center;
     color: var(--text-secondary);
 }
@@ -122,7 +133,7 @@ img {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0.65rem 1.75rem;
+    padding: 0.5rem 1.25rem;
     border-radius: 999px;
     background: rgba(56, 189, 248, 0.16);
     color: var(--accent);
@@ -139,13 +150,13 @@ img {
     gap: 0.35rem;
     align-items: center;
     justify-content: center;
-    min-width: min(170px, 100%);
-    padding: clamp(0.65rem, 2vw, 0.85rem) clamp(1rem, 3vw, 1.5rem);
+    min-width: min(150px, 100%);
+    padding: clamp(0.55rem, 1.5vw, 0.75rem) clamp(0.85rem, 2.5vw, 1.25rem);
     border-radius: var(--radius-md);
     border: 1px solid rgba(148, 163, 184, 0.18);
     background: rgba(148, 163, 184, 0.08);
     font-weight: 600;
-    font-size: clamp(1rem, 2vw, 1.25rem);
+    font-size: clamp(0.9rem, 1.75vw, 1.1rem);
 }
 
 .stat-chip::before {
@@ -180,14 +191,14 @@ img {
 
 .card {
     position: relative;
-    flex: 1 1 clamp(180px, 32vw, 240px);
-    max-width: clamp(210px, 40vw, 260px);
-    min-height: clamp(250px, 52vw, 340px);
+    flex: 1 1 clamp(160px, 28vw, 220px);
+    max-width: clamp(200px, 36vw, 240px);
+    min-height: clamp(210px, 46vw, 300px);
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: clamp(0.65rem, 2vw, 0.95rem);
-    padding: clamp(0.85rem, 2vw, 1.2rem) clamp(0.75rem, 1.8vw, 1.1rem) clamp(1rem, 2.5vw, 1.6rem);
+    gap: clamp(0.5rem, 1.6vw, 0.8rem);
+    padding: clamp(0.7rem, 1.6vw, 1rem) clamp(0.6rem, 1.6vw, 0.9rem) clamp(0.85rem, 2vw, 1.3rem);
     border-radius: 24px;
     background: linear-gradient(185deg, var(--trump-navy) 0%, rgba(6, 54, 90, 0.9) 60%, rgba(14, 23, 42, 0.96) 100%);
     border: 3px solid var(--trump-gold);
@@ -228,14 +239,15 @@ img {
 }
 
 .card img {
-    width: min(100%, clamp(140px, 55vw, 190px));
+    width: 100%;
+    flex: 1 1 auto;
     aspect-ratio: 3 / 4;
     object-fit: contain;
     border-radius: 18px;
     background: radial-gradient(circle at center, rgba(56, 189, 248, 0.22), rgba(15, 23, 42, 0.75) 80%);
     border: 2px solid rgba(248, 250, 252, 0.25);
     box-shadow: 0 16px 28px rgba(15, 23, 42, 0.6);
-    padding: clamp(0.5rem, 1.5vw, 0.75rem);
+    padding: clamp(0.45rem, 1.2vw, 0.65rem);
 }
 
 .pokemon-label {
@@ -243,14 +255,14 @@ img {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: clamp(0.5rem, 2vw, 0.85rem);
-    padding: clamp(0.45rem, 1.5vw, 0.65rem) clamp(0.6rem, 2vw, 0.95rem);
+    gap: clamp(0.4rem, 1.5vw, 0.7rem);
+    padding: clamp(0.35rem, 1.2vw, 0.55rem) clamp(0.5rem, 1.5vw, 0.8rem);
     border-radius: 18px;
     border: 2px solid rgba(255, 255, 255, 0.35);
     background: linear-gradient(135deg, var(--trump-gold), var(--trump-orange));
     color: #1f2937;
     font-weight: 800;
-    font-size: clamp(0.78rem, 1.6vw, 0.9rem);
+    font-size: clamp(0.7rem, 1.4vw, 0.85rem);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     text-shadow: 0 1px 0 rgba(255, 255, 255, 0.55);
@@ -272,7 +284,7 @@ img {
     width: 100%;
     display: flex;
     flex-direction: column;
-    gap: clamp(0.5rem, 1.5vw, 0.7rem);
+    gap: clamp(0.45rem, 1.4vw, 0.65rem);
 }
 
 .stat-options button {
@@ -280,14 +292,14 @@ img {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: clamp(0.6rem, 2vw, 0.85rem);
-    padding: clamp(0.6rem, 1.8vw, 0.85rem) clamp(0.75rem, 2vw, 1rem);
+    gap: clamp(0.5rem, 1.6vw, 0.75rem);
+    padding: clamp(0.5rem, 1.6vw, 0.75rem) clamp(0.65rem, 1.8vw, 0.9rem);
     border-radius: 16px;
     border: 2px solid rgba(250, 204, 21, 0.25);
     background: rgba(15, 23, 42, 0.78);
     color: var(--text-primary);
     font-weight: 700;
-    font-size: clamp(0.8rem, 1.4vw, 0.95rem);
+    font-size: clamp(0.75rem, 1.3vw, 0.9rem);
     letter-spacing: 0.04em;
     cursor: pointer;
     transition: var(--transition);
@@ -346,7 +358,7 @@ img {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0.55rem 1.35rem;
+    padding: 0.45rem 1.1rem;
     border-radius: 999px;
     background: linear-gradient(135deg, rgba(250, 204, 21, 0.25), rgba(249, 115, 22, 0.35));
     color: var(--text-primary);
@@ -357,9 +369,9 @@ img {
 
 .log {
     width: 100%;
-    min-height: clamp(110px, 30vh, 160px);
-    max-height: clamp(160px, 45vh, 240px);
-    padding: clamp(0.75rem, 1.5vw, 1rem);
+    min-height: clamp(100px, 25vh, 150px);
+    max-height: clamp(150px, 40vh, 210px);
+    padding: clamp(0.65rem, 1.4vw, 0.9rem);
     border-radius: var(--radius-md);
     border: 1px solid rgba(148, 163, 184, 0.18);
     background: rgba(10, 18, 32, 0.65);
@@ -375,13 +387,13 @@ img {
 }
 
 .primary-action {
-    margin-top: clamp(1rem, 2.5vw, 1.5rem);
-    padding: clamp(0.75rem, 2vw, 0.95rem) clamp(1.5rem, 6vw, 2.75rem);
+    margin-top: clamp(0.75rem, 2vw, 1.25rem);
+    padding: clamp(0.65rem, 1.6vw, 0.85rem) clamp(1.25rem, 5vw, 2.25rem);
     border-radius: 999px;
     border: none;
     outline: none;
     font-weight: 700;
-    font-size: clamp(0.9rem, 1.6vw, 1rem);
+    font-size: clamp(0.85rem, 1.4vw, 0.95rem);
     letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--text-primary);
@@ -401,14 +413,20 @@ img {
     width: 100%;
     display: flex;
     flex-direction: column;
-    gap: clamp(1rem, 2.5vw, 1.5rem);
+    gap: clamp(0.75rem, 2vw, 1.35rem);
     background: var(--surface-strong);
     border-radius: var(--radius-lg);
     border: 1px solid var(--card-border);
-    padding: clamp(1.1rem, 3vw, 2.5rem);
+    padding: clamp(0.9rem, 2.5vw, 1.75rem);
     box-shadow: var(--shadow-lg);
     backdrop-filter: blur(18px);
-    overflow: hidden;
+    max-height: calc(100vh - clamp(4rem, 12vh, 6rem));
+    overflow-y: auto;
+    align-items: center;
+}
+
+.menu > * {
+    width: 100%;
 }
 
 .menu-message {
@@ -437,7 +455,7 @@ img {
 .packs {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(clamp(140px, 30vw, 190px), 1fr));
-    gap: clamp(0.85rem, 2vw, 1.5rem);
+    gap: clamp(0.65rem, 1.75vw, 1.1rem);
 }
 
 .pokemon-pack {
@@ -445,8 +463,8 @@ img {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: clamp(0.7rem, 2vw, 0.9rem);
-    padding: clamp(0.9rem, 2.5vw, 1.25rem);
+    gap: clamp(0.55rem, 1.6vw, 0.75rem);
+    padding: clamp(0.75rem, 2vw, 1.1rem);
     border-radius: var(--radius-md);
     border: 1px solid var(--card-border);
     background: rgba(12, 20, 35, 0.7);
@@ -464,8 +482,10 @@ img {
 }
 
 .pokemon-pack img {
-    width: clamp(80px, 25vw, 110px);
-    height: clamp(80px, 25vw, 110px);
+    width: 100%;
+    height: auto;
+    max-width: 120px;
+    aspect-ratio: 1 / 1;
     object-fit: contain;
     filter: drop-shadow(0 16px 24px rgba(8, 15, 35, 0.55));
 }
@@ -473,11 +493,11 @@ img {
 .rules {
     display: flex;
     flex-direction: column;
-    gap: clamp(0.65rem, 2vw, 0.85rem);
+    gap: clamp(0.5rem, 1.6vw, 0.75rem);
     background: rgba(12, 20, 35, 0.65);
     border-radius: var(--radius-md);
     border: 1px solid rgba(148, 163, 184, 0.2);
-    padding: clamp(1rem, 2.5vw, 1.5rem);
+    padding: clamp(0.75rem, 2vw, 1.1rem);
     color: var(--text-secondary);
     line-height: 1.6;
 }
@@ -490,8 +510,8 @@ img {
 .rules ol {
     display: flex;
     flex-direction: column;
-    gap: clamp(0.4rem, 1.5vw, 0.6rem);
-    padding-left: clamp(1rem, 2.5vw, 1.25rem);
+    gap: clamp(0.3rem, 1.2vw, 0.5rem);
+    padding-left: clamp(0.75rem, 2vw, 1rem);
 }
 
 .rules li {
@@ -501,11 +521,11 @@ img {
 .type-chart {
     display: flex;
     flex-direction: column;
-    gap: clamp(0.75rem, 2.5vw, 1rem);
+    gap: clamp(0.55rem, 1.8vw, 0.85rem);
     background: rgba(12, 20, 35, 0.65);
     border-radius: var(--radius-md);
     border: 1px solid rgba(148, 163, 184, 0.2);
-    padding: clamp(1rem, 2.5vw, 1.5rem);
+    padding: clamp(0.75rem, 2vw, 1.1rem);
 }
 
 .type-chart-title {


### PR DESCRIPTION
## Summary
- tighten global spacing and center the layout to keep the interface within the viewport
- shrink card, menu, and rules blocks while keeping content scrollable when necessary
- scale card and pack imagery so pictures adapt to their parent containers

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d46fe04554832f978a3df3fda51fab